### PR TITLE
입력한 비밀번호 확인과 비밀번호가 달라도 Validation 에 성공하는 문제를 해결합니다.

### DIFF
--- a/UniPlogger/Scene/Registration/RegistrationInteractor.swift
+++ b/UniPlogger/Scene/Registration/RegistrationInteractor.swift
@@ -50,8 +50,12 @@ class RegistrationInteractor: RegistrationBusinessLogic, RegistrationDataStore {
     }
     
     func validatePasswordConfirm(request: Registration.ValidatePasswordConfirm.Request){
-        let text = request.password
-        let result = worker.validatePassword(text: text)
+        let password = request.password
+        let passwordConfirm = request.passwordConfirm
+        let result = worker.validatePasswordConfirm(
+            password: password,
+            passwordConfirm: passwordConfirm
+        )
         presenter?.presentValidatePasswordConfirm(response: .init(isValid: result))
     }
     

--- a/UniPlogger/Scene/Registration/RegistrationModels.swift
+++ b/UniPlogger/Scene/Registration/RegistrationModels.swift
@@ -50,6 +50,7 @@ enum Registration {
     enum ValidatePasswordConfirm{
       struct Request{
         var password: String
+        var passwordConfirm: String
       }
       struct Response{
         var isValid: Bool

--- a/UniPlogger/Scene/Registration/RegistrationViewController.swift
+++ b/UniPlogger/Scene/Registration/RegistrationViewController.swift
@@ -53,6 +53,7 @@ class RegistrationViewController: UIViewController {
         $0.borderStyle = .none
         $0.placeholder = "비밀번호"
         $0.addTarget(self, action: #selector(validatePassword), for: .editingChanged)
+        $0.addTarget(self, action: #selector(validatePasswordConfirm), for: .editingChanged)
     }
     
     let passwordInfoLabel = UILabel().then {
@@ -75,6 +76,7 @@ class RegistrationViewController: UIViewController {
         $0.backgroundColor = .clear
         $0.borderStyle = .none
         $0.placeholder = "비밀번호 재입력"
+        $0.addTarget(self, action: #selector(validatePassword), for: .editingChanged)
         $0.addTarget(self, action: #selector(validatePasswordConfirm), for: .editingChanged)
     }
     

--- a/UniPlogger/Scene/Registration/RegistrationViewController.swift
+++ b/UniPlogger/Scene/Registration/RegistrationViewController.swift
@@ -179,8 +179,12 @@ class RegistrationViewController: UIViewController {
     }
     
     @objc func validatePasswordConfirm(){
-        guard let text = passwordConfirmField.text else { return }
-        let request = Registration.ValidatePasswordConfirm.Request(password: text)
+        guard let password = passwordField.text else { return }
+        guard let passwordConfirm = passwordConfirmField.text else { return }
+        let request = Registration.ValidatePasswordConfirm.Request(
+            password: password,
+            passwordConfirm: passwordConfirm
+        )
         self.interactor?.validatePasswordConfirm(request: request)
     }
     

--- a/UniPlogger/Scene/Registration/RegistrationWorker.swift
+++ b/UniPlogger/Scene/Registration/RegistrationWorker.swift
@@ -23,6 +23,10 @@ class RegistrationWorker {
     func validatePassword(text: String) -> Bool{
         return text.count >= 8 && text.count <= 20
     }
+
+    func validatePasswordConfirm(password: String, passwordConfirm: String) -> Bool{
+        return validatePassword(text: passwordConfirm) && password == passwordConfirm
+    }
     
     func validateNickname(text: String) -> Bool{
         return text.count >= 1 && text.count <= 6

--- a/UniPlogger/Scene/ResetPassword/ResetPasswordInteractor.swift
+++ b/UniPlogger/Scene/ResetPassword/ResetPasswordInteractor.swift
@@ -43,8 +43,9 @@ class ResetPasswordInteractor: ResetPasswordBusinessLogic, ResetPasswordDataStor
     }
     
     func validatePasswordConfirm(request: ResetPassword.ValidatePasswordConfirm.Request){
-        let text = request.password
-        let result = worker.validatePassword(text: text)
+        let password = request.password
+        let passwordConfirm = request.passwordConfirm
+        let result = worker.validatePasswordConfirm(password: password, passwordConfirm: passwordConfirm)
         presenter?.presentValidatePasswordConfirm(response: .init(isValid: result))
     }
 }

--- a/UniPlogger/Scene/ResetPassword/ResetPasswordModels.swift
+++ b/UniPlogger/Scene/ResetPassword/ResetPasswordModels.swift
@@ -48,6 +48,7 @@ enum ResetPassword {
     enum ValidatePasswordConfirm{
       struct Request{
         var password: String
+        var passwordConfirm: String
       }
       struct Response{
         var isValid: Bool

--- a/UniPlogger/Scene/ResetPassword/ResetPasswordViewController.swift
+++ b/UniPlogger/Scene/ResetPassword/ResetPasswordViewController.swift
@@ -48,6 +48,7 @@ class ResetPasswordViewController: UIViewController {
         $0.borderStyle = .none
         $0.attributedPlaceholder = NSMutableAttributedString().string("비밀번호", font: .notoSans(ofSize: 16, weight: .regular), color: .white)
         $0.addTarget(self, action: #selector(validatePassword), for: .editingChanged)
+        $0.addTarget(self, action: #selector(validatePasswordConfirm), for: .editingChanged)
     }
     
     let password2FieldBox = UIView().then {
@@ -64,6 +65,7 @@ class ResetPasswordViewController: UIViewController {
         $0.backgroundColor = .clear
         $0.borderStyle = .none
         $0.attributedPlaceholder = NSMutableAttributedString().string("비밀번호 재입력", font: .notoSans(ofSize: 16, weight: .regular), color: .white)
+        $0.addTarget(self, action: #selector(validatePassword), for: .editingChanged)
         $0.addTarget(self, action: #selector(validatePasswordConfirm), for: .editingChanged)
     }
     

--- a/UniPlogger/Scene/ResetPassword/ResetPasswordViewController.swift
+++ b/UniPlogger/Scene/ResetPassword/ResetPasswordViewController.swift
@@ -199,8 +199,12 @@ class ResetPasswordViewController: UIViewController {
     }
     
     @objc func validatePasswordConfirm(){
-        guard let text = password2Field.text else { return }
-        let request = ResetPassword.ValidatePasswordConfirm.Request(password: text)
+        guard let password = password1Field.text else { return }
+        guard let passwordConfirm = password2Field.text else { return }
+        let request = ResetPassword.ValidatePasswordConfirm.Request(
+            password: password,
+            passwordConfirm: passwordConfirm
+        )
         self.interactor?.validatePasswordConfirm(request: request)
     }
     

--- a/UniPlogger/Scene/ResetPassword/ResetPasswordWorker.swift
+++ b/UniPlogger/Scene/ResetPassword/ResetPasswordWorker.swift
@@ -16,6 +16,10 @@ class ResetPasswordWorker {
     func validatePassword(text: String) -> Bool{
         return text.count >= 8 && text.count <= 20
     }
+
+    func validatePasswordConfirm(password: String, passwordConfirm: String) -> Bool{
+        return validatePassword(text: passwordConfirm) && password == passwordConfirm
+    }
     
     
     func findPassword(


### PR DESCRIPTION
# 배경
가입 화면 / 비밀번호 초기화 화면에서 비밀번호 입력과 비밀번호 재입력이 서로 달라도 Validation 이 성공하는 문제가 있습니다.

# 작업 내용
- 가입 화면 / 비밀번호 초기화 화면에서 비밀번호 재입력 값을 검증할 때 올바른 비밀번호인지와 비밀번호화 일치하는지 여부까지 검증합니다.
- 비밀번호, 비밀번호 재입력 서로 값이 변했을 때 서로를 검증하도록 합니다.